### PR TITLE
 refactor: use relative paths to import from "src"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,28 +2,23 @@
 # ======== Default Profile ========
 # =================================
 [profile.default]
-verbosity = 3
-remappings = [
-  # Allows imports using e.g. `test/` to refer to root `test` directory.
-  "test/=test/",
-  "script/=script/",
-]
+  verbosity = 3
 
 # ============================
 # ======== CI Profile ========
 # ============================
 [profile.ci.fuzz]
-runs = 10000
+  runs = 10000
 
 # ============================
 # ======== Formatting ========
 # ============================
 [profile.default.fmt]
-line_length = 80
-tab_width = 2
-bracket_spacing = false
-int_types = 'short'
-multiline_func_header = 'attributes_first'
-quote_style = 'double'
-number_underscore = 'thousands'
-single_line_statement_blocks = 'single'
+  line_length = 80
+  tab_width = 2
+  bracket_spacing = false
+  int_types = 'short'
+  multiline_func_header = 'attributes_first'
+  quote_style = 'double'
+  number_underscore = 'thousands'
+  single_line_statement_blocks = 'single'

--- a/test/Generators.t.sol
+++ b/test/Generators.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import {linspace, arange, logspace, range} from "src/Generators.sol";
+import {linspace, arange, logspace, range} from "../src/Generators.sol";
 
 // =======================
 // ======== Setup ========


### PR DESCRIPTION
## Description

Fixes https://github.com/foundry-rs/foundry/issues/3440 for users who need this library.

There really is just one place where `src/` is used as an import path, so I think that switching it to `../src` and deleting the remappings is well worth it given Foundry's limited capability to handle nested remappings.

## Changelog

- [x] refactor: use relative paths to import from "src"
- [x] chore: delete "remappings" config option from Foundry config
- [x] style: format "foundry.toml" with Taplo

