### PR TITLE
Refactor "arange" to "arrange" (double "r")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solidity Array Generators
 
-Solidity library offering `linspace`, `arange`, and `logspace` methods to generate evenly spaced arrays.
+Solidity library offering `linspace`, `arrange`, and `logspace` methods to generate evenly spaced arrays.
 Both signed and unsigned integers are supported.
 
 This library was written for use in development/testing:
@@ -30,8 +30,8 @@ This library generates evenly spaced arrays between the specified start and stop
 Function names and signatures are similar to those of [numpy](https://numpy.org/), and this library currently supports:
 
 - `linspace`: Returns linearly spaced numbers over a specified interval, specifying the length of the array. Defaults to 50 elements in the array if not specified.
-- `arange`: Returns linearly spaced numbers over a specified interval, specifying the step size. Defaults to a step size of 1 if not specified.
-- `logspace`: Returns numbers spaced evenly on a log scale. Unlike `linspace` and `arange`, you don't enter the start and stop values directly, but their exponents. Start and stop values are then calculated as `base ** start` and `base ** stop`. Defaults to 50 elements in the array and a base of 10 if not specified.
+- `arrange`: Returns linearly spaced numbers over a specified interval, specifying the step size. Defaults to a step size of 1 if not specified.
+- `logspace`: Returns numbers spaced evenly on a log scale. Unlike `linspace` and `arrange`, you don't enter the start and stop values directly, but their exponents. Start and stop values are then calculated as `base ** start` and `base ** stop`. Defaults to 50 elements in the array and a base of 10 if not specified.
 
 Each method behaves as follows:
 
@@ -50,7 +50,7 @@ If there is demand for it, a future version may remove this restriction.
 ## Examples
 
 ```solidity
-import {linspace, arange, logspace} from "solidity-generators/Generators.sol";
+import {linspace, arrange, logspace} from "solidity-generators/Generators.sol";
 
 uint256 ustart = 0;
 uint256 ustop  = 1000;
@@ -83,21 +83,21 @@ linspace(istart, istop, 51);
 // Returns [-1000, -960, -920, ..., 880, 920, 960, 1000]
 
 // ========================
-// ======== Arange ========
+// ======== Arrange ========
 // ========================
 // Linear spacing, by step size.
 
-arange(ustart, ustop);
+arrange(ustart, ustop);
 // Returns [0, 1, 2, ..., 998, 999, 1000]
 
-arange(ustart, ustop, 250);
+arrange(ustart, ustop, 250);
 // Returns [0, 250, 500, 750, 1000]
 
 
-arange(istart, istop, 500);
+arrange(istart, istop, 500);
 // Returns [-1000, -500, 0, 500, 1000]
 
-arange(istart, istop);
+arrange(istart, istop);
 // Returns [-1000, -999, -998, ..., 998, 999, 1000]
 
 // ==========================
@@ -116,7 +116,7 @@ logspace(2, 10, 9, 2); // Base 2.
 // ================================
 
 // We can flip the order for a descending array.
-arange(istop, istart);
+arrange(istop, istart);
 // Returns [1000, 999, 998, ..., -998, -999, -1000]
 
 logspace(6, 0, 7); // Base 10.
@@ -127,6 +127,6 @@ logspace(6, 0, 7); // Base 10.
 linspace(ustart, 10, 4);
 // Returns [0, 3, 6, 9]
 
-arange(ustart, 10, 3);
+arrange(ustart, 10, 3);
 // Returns [0, 3, 6, 9]
 ```

--- a/src/Generators.sol
+++ b/src/Generators.sol
@@ -82,21 +82,21 @@ function linspace(int start, int stop, uint num)
 }
 
 // ========================
-// ======== Arange ========
+// ======== Arrange ========
 // ========================
 // Linear spacing, by step size.
 
 // Default to a step size of 1.
-function arange(uint start, uint stop) pure returns (uint[] memory arr) {
-  arr = arange(start, stop, 1);
+function arrange(uint start, uint stop) pure returns (uint[] memory arr) {
+  arr = arrange(start, stop, 1);
 }
 
-function arange(int start, int stop) pure returns (int[] memory arr) {
-  arr = arange(start, stop, 1);
+function arrange(int start, int stop) pure returns (int[] memory arr) {
+  arr = arrange(start, stop, 1);
 }
 
 // Specify the step size.
-function arange(uint start, uint stop, uint step)
+function arrange(uint start, uint stop, uint step)
   pure
   returns (uint[] memory arr)
 {
@@ -104,7 +104,7 @@ function arange(uint start, uint stop, uint step)
   arr = linspace(start, stop, num);
 }
 
-function arange(int start, int stop, uint step) pure returns (int[] memory arr) {
+function arrange(int start, int stop, uint step) pure returns (int[] memory arr) {
   uint num = (range(start, stop) / step) + 1;
   arr = linspace(start, stop, num);
 }

--- a/test/Generators.t.sol
+++ b/test/Generators.t.sol
@@ -94,22 +94,22 @@ contract LinspaceSigned is GeneratorsTest {
 }
 
 // =======================
-// ======== Arange ========
+// ======== Arrange ========
 // =======================
 
-contract ArangeUnsigned is GeneratorsTest {
+contract ArrangeUnsigned is GeneratorsTest {
   function test_Ascending() public {
-    uint[] memory array = arange(uint(0), 10, 1);
+    uint[] memory array = arrange(uint(0), 10, 1);
     assertEq(array, unsignedExpectedAscending);
   }
 
   function test_Descending() public {
-    uint[] memory array = arange(uint(10), 0, 1);
+    uint[] memory array = arrange(uint(10), 0, 1);
     assertEq(array, unsignedExpectedDescending);
   }
 
   function test_StartEqualsStop() public {
-    uint[] memory array = arange(uint(25), 25);
+    uint[] memory array = arrange(uint(25), 25);
     assertEq(array.length, 1);
     assertEq(array[0], 25);
   }
@@ -119,29 +119,29 @@ contract ArangeUnsigned is GeneratorsTest {
     if (stop > start && stop - start > 1000) start = stop - 1000;
     if (stop < start && start - stop > 1000) stop = start - 1000;
 
-    uint[] memory a = arange(start, stop);
-    uint[] memory b = arange(start, stop, 1);
+    uint[] memory a = arrange(start, stop);
+    uint[] memory b = arrange(start, stop, 1);
     assertEq(a, b);
   }
 }
 
-contract ArangeSigned is GeneratorsTest {
+contract ArrangeSigned is GeneratorsTest {
   function test_Ascending() public {
-    int[] memory array = arange(-5, 5, 1);
+    int[] memory array = arrange(-5, 5, 1);
     assertEq(array, signedExpectedAscending);
   }
 
   function test_Descending() public {
-    int[] memory array = arange(5, -5, 1);
+    int[] memory array = arrange(5, -5, 1);
     assertEq(array, signedExpectedDescending);
   }
 
   function test_StartEqualsStop() public {
-    int[] memory array = arange(int(25), 25);
+    int[] memory array = arrange(int(25), 25);
     assertEq(array.length, 1);
     assertEq(array[0], 25);
 
-    int[] memory array2 = arange(-20, -20);
+    int[] memory array2 = arrange(-20, -20);
     assertEq(array2.length, 1);
     assertEq(array2[0], -20);
   }
@@ -151,8 +151,8 @@ contract ArangeSigned is GeneratorsTest {
     if (stop > start && range(start, stop) > 1000) start = stop - 1000;
     if (stop < start && range(start, stop) > 1000) stop = start - 1000;
 
-    int[] memory a = arange(start, stop);
-    int[] memory b = arange(start, stop, 1);
+    int[] memory a = arrange(start, stop);
+    int[] memory b = arrange(start, stop, 1);
     assertEq(a, b);
   }
 }


### PR DESCRIPTION
I may be a little pedantic, but I think that it is useful to rename the `arange` function to `arrange`, because:

1. This is how the word in spelled in the dictionary.
2. More importantly, "arange" can be interpreted to mean "a range", and this library also offers a `range` function, so this is a bit of a terminology overlap.

I actually bumped into point 2 in my private repo:

```solidity
import { arange, range } from "solidity-generators/Generators.sol";
```