### PR TITLE
build: bump forge-std

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/forge-std"]
+	branch = v1
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
Bump and also pin `forge-std` to `v1`.

The benefit of pinning is that it leads to more predictable builds (if this can be said about git submodules, anyway).

I use this repo (`solidity-generators`) in a project with many git submodules. Pinning your version of `forge-std` to `v1` helps reduce the installation time when pulling a fresh copy of the repo for the first time.